### PR TITLE
Refactor SQL value formatting and unify query builder behavior

### DIFF
--- a/src/Clausules/WhereClausule.php
+++ b/src/Clausules/WhereClausule.php
@@ -4,6 +4,7 @@ namespace Leonardocrcst\QueryBuilder\Clausules;
 
 use InvalidArgumentException;
 use Leonardocrcst\QueryBuilder\Types\ExpressionType;
+use Leonardocrcst\QueryBuilder\Utils\Formatter;
 
 class WhereClausule
 {
@@ -63,25 +64,10 @@ class WhereClausule
                     );
                 case 'IN':
                 case 'NOT IN':
-                    return '(' . implode(', ', $this->formatValue($value)) . ')';
+                    return '(' . implode(', ', Formatter::formatValue($value)) . ')';
             }
         }
-        return $this->formatValue($value);
-    }
-
-    private function formatValue(mixed $value): string|int|array|float
-    {
-        if (is_array($value)) {
-            return array_map(fn($v) => $this->formatValue($v), $value);
-        }
-        if (is_numeric($value)) {
-            return $value;
-        }
-        return match (gettype($value)) {
-            'boolean' => $value ? 'true' : 'false',
-            'NULL' => 'NULL',
-            default => "'$value'"
-        };
+        return Formatter::formatValue($value);
     }
 
     public function or(string $column, ExpressionType $expressionType, mixed $value): WhereClausule

--- a/src/DeleteQueryBuilder.php
+++ b/src/DeleteQueryBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Leonardocrcst\QueryBuilder;
 
+use Leonardocrcst\QueryBuilder\Utils\Formatter;
+
 class DeleteQueryBuilder
 {
     private string $column;
@@ -16,8 +18,8 @@ class DeleteQueryBuilder
     {
         $this->column = $column;
         $this->values = sprintf(
-            '"%s"',
-            implode('", "', $values)
+            '%s',
+            implode(', ', Formatter::formatValue($values))
         );
         return $this;
     }

--- a/src/InsertQueryBuilder.php
+++ b/src/InsertQueryBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Leonardocrcst\QueryBuilder;
 
+use Leonardocrcst\QueryBuilder\Utils\Formatter;
+
 class InsertQueryBuilder
 {
     private array $rows = [];
@@ -13,7 +15,7 @@ class InsertQueryBuilder
 
     public function value(string $column, mixed $value, int $row = 0): InsertQueryBuilder
     {
-        $this->rows[$row][$column] = $value;
+        $this->rows[$row][$column] = Formatter::formatValue($value);
         return $this;
     }
 
@@ -23,7 +25,7 @@ class InsertQueryBuilder
             'INSERT INTO %s (%s) VALUES %s',
             $this->table,
             implode(", ", array_keys($this->rows[0])),
-            implode(", ", array_map(fn($row) => sprintf("('%s')", implode("', '", $row)), $this->rows))
+            implode(", ", array_map(fn($row) => sprintf("(%s)", implode(", ", $row)), $this->rows))
         ));
     }
 }

--- a/src/UpdateQueryBuilder.php
+++ b/src/UpdateQueryBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Leonardocrcst\QueryBuilder;
 
+use Leonardocrcst\QueryBuilder\Utils\Formatter;
+
 class UpdateQueryBuilder
 {
     private array $values = [];
@@ -17,7 +19,12 @@ class UpdateQueryBuilder
         if (!isset($this->values[$column])) {
             $this->values[$column] = [" = CASE $caseColumn"];
         }
-        $this->values[$column][] = "WHEN '$whenValue' THEN '$value'";
+        //$this->values[$column][] = "WHEN '$whenValue' THEN '$value'";
+        $this->values[$column][] = sprintf(
+            "WHEN %s THEN %s",
+            Formatter::formatValue($whenValue),
+            Formatter::formatValue($value)
+        );
         $this->wheres[$caseColumn][] = $whenValue;
     }
 
@@ -46,7 +53,7 @@ class UpdateQueryBuilder
     {
        $where = [];
        foreach ($this->wheres as $column => $values) {
-           $where[] = "$column IN ('" . implode("', '", array_unique($values)) . "')";
+           $where[] = "$column IN (" . implode(", ", array_unique($values)) . ")";
        }
        return implode(' AND ', $where);
     }

--- a/src/Utils/Formatter.php
+++ b/src/Utils/Formatter.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Leonardocrcst\QueryBuilder\Utils;
+
+abstract class Formatter
+{
+    public static function formatValue(mixed $value): string|int|array|float
+    {
+        if (is_array($value)) {
+            return array_map(fn($v) => self::formatValue($v), $value);
+        }
+        if (is_numeric($value)) {
+            return $value;
+        }
+        return match (gettype($value)) {
+            'boolean' => $value ? 'true' : 'false',
+            'NULL' => 'NULL',
+            default => "'$value'"
+        };
+    }
+}

--- a/tests/DeleteBuilderTest.php
+++ b/tests/DeleteBuilderTest.php
@@ -12,6 +12,6 @@ class DeleteBuilderTest extends TestCase
         $builder = new DeleteQueryBuilder('table');
         $builder->value('id', [1,2,'test']);
 
-        $this->assertEquals('DELETE FROM table WHERE id IN ("1", "2", "test")', (string) $builder);
+        $this->assertEquals("DELETE FROM table WHERE id IN (1, 2, 'test')", (string) $builder);
     }
 }

--- a/tests/InsertBuilderTest.php
+++ b/tests/InsertBuilderTest.php
@@ -13,7 +13,7 @@ class InsertBuilderTest extends TestCase
         $insert->value('id', 1);
         $insert->value('name', 'test');
 
-        $this->assertEquals("INSERT INTO table (id, name) VALUES ('1', 'test')", (string) $insert);
+        $this->assertEquals("INSERT INTO table (id, name) VALUES (1, 'test')", (string) $insert);
     }
 
     public function testInsertQueryBuilderWithMultipleRows(): void
@@ -24,6 +24,6 @@ class InsertBuilderTest extends TestCase
         $insert->value('id', 2, 1);
         $insert->value('name', 'another test', 1);
 
-        $this->assertEquals("INSERT INTO table (id, name) VALUES ('1', 'test'), ('2', 'another test')", (string) $insert);
+        $this->assertEquals("INSERT INTO table (id, name) VALUES (1, 'test'), (2, 'another test')", (string) $insert);
     }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -20,14 +20,14 @@ class QueryBuilderTest extends TestCase
                 'name' => 'another test',
             ]
         ]);
-        $this->assertEquals("INSERT INTO table (id, name) VALUES ('1', 'test'), ('2', 'another test')", (string) $query);
+        $this->assertEquals("INSERT INTO table (id, name) VALUES (1, 'test'), (2, 'another test')", (string) $query);
     }
 
     public function testDeleteQuery(): void
     {
         $builder = new QueryBuilder('table');
         $query = $builder->delete('id', [1,2,'test']);
-        $this->assertEquals('DELETE FROM table WHERE id IN ("1", "2", "test")', (string) $query);
+        $this->assertEquals("DELETE FROM table WHERE id IN (1, 2, 'test')", (string) $query);
     }
 
     public function testUpdateQuery(): void
@@ -37,7 +37,7 @@ class QueryBuilderTest extends TestCase
         $update->value('name', 'test', 'id', 1);
         $update->value('name', 'another test', 'id', 2);
 
-        $this->assertEquals("UPDATE table SET name = CASE id WHEN '1' THEN 'test' WHEN '2' THEN 'another test' ELSE name END WHERE id IN ('1', '2')", (string) $update);
+        $this->assertEquals("UPDATE table SET name = CASE id WHEN 1 THEN 'test' WHEN 2 THEN 'another test' ELSE name END WHERE id IN (1, 2)", (string) $update);
     }
 
     public function testSelectQuery(): void

--- a/tests/UpdateBuilderTest.php
+++ b/tests/UpdateBuilderTest.php
@@ -13,7 +13,7 @@ class UpdateBuilderTest extends TestCase
         $builder->value('name', 'test', 'id', 1);
         $builder->value('name', 'another test', 'id', 2);
 
-        $this->assertEquals("UPDATE table SET name = CASE id WHEN '1' THEN 'test' WHEN '2' THEN 'another test' ELSE name END WHERE id IN ('1', '2')", (string) $builder);
+        $this->assertEquals("UPDATE table SET name = CASE id WHEN 1 THEN 'test' WHEN 2 THEN 'another test' ELSE name END WHERE id IN (1, 2)", (string) $builder);
     }
 
     public function testUpdateBuilderWithMultipleColumns(): void
@@ -24,6 +24,6 @@ class UpdateBuilderTest extends TestCase
         $builder->value('name', 'another test', 'id', 2);
         $builder->value('value', 2, 'id', 2);
 
-        $this->assertEquals("UPDATE table SET name = CASE id WHEN '1' THEN 'test' WHEN '2' THEN 'another test' ELSE name END, value = CASE id WHEN '1' THEN '1' WHEN '2' THEN '2' ELSE value END WHERE id IN ('1', '2')", (string) $builder);
+        $this->assertEquals("UPDATE table SET name = CASE id WHEN 1 THEN 'test' WHEN 2 THEN 'another test' ELSE name END, value = CASE id WHEN 1 THEN 1 WHEN 2 THEN 2 ELSE value END WHERE id IN (1, 2)", (string) $builder);
     }
 }


### PR DESCRIPTION
---

### What does this implement/fix?

This pull request introduces the `Formatter` utility class to standardize SQL value formatting across query builders. The changes include:

- Centralizing SQL value formatting logic with the new `Formatter` utility class.
- Updating the `InsertQueryBuilder`, `UpdateQueryBuilder`, `DeleteQueryBuilder`, and `WhereClausule` to utilize the `Formatter` for consistent value handling.
- Removing redundant formatting logic from the `WhereClausule`.
- Enhancing test cases to assert proper SQL generation with accurate formatting (e.g., removing unnecessary quotes around numeric values).

### Why is this needed?

To reduce code duplication, ensure consistent behavior across query builders, and facilitate easier maintenance of SQL value formatting logic.

### Additional Information

The updates enhance clarity in SQL generation while maintaining consistency and reducing redundant logic across tests and query classes.